### PR TITLE
Sanitize using Forem::Sanitizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea/

--- a/lib/forem/formatters/redcarpet_gfm.rb
+++ b/lib/forem/formatters/redcarpet_gfm.rb
@@ -7,7 +7,7 @@ module Forem
         formatter = ::Redcarpet::Markdown.new(::Redcarpet::Render::HTML,
           :no_intra_emphasis => true, :fenced_code_blocks => true,
           :autolink => true, :lax_html_blocks => true)
-        formatter.render(ERB::Util.h(text)).html_safe
+        formatter.render(Forem::Sanitizer.sanitize(text)).html_safe
       end
 
 

--- a/lib/forem/formatters/redcarpet_gfm.rb
+++ b/lib/forem/formatters/redcarpet_gfm.rb
@@ -7,14 +7,14 @@ module Forem
         formatter = ::Redcarpet::Markdown.new(::Redcarpet::Render::HTML,
           :no_intra_emphasis => true, :fenced_code_blocks => true,
           :autolink => true, :lax_html_blocks => true)
-        formatter.render(Forem::Sanitizer.sanitize(text)).html_safe
+        formatter.render(text).html_safe
       end
 
 
       def self.blockquote(text)
         text.split("\n").map do |line|
           "> " + line
-        end.join("\n")
+        end.join("\n") + "\n\n"
       end
     end
   end


### PR DESCRIPTION
Using `ERB::Util.h()` was good for a time, until it started escaping _everything and anything_...

So in Forem we now have a `Forem::Sanitizer` class which delegates out to the sanitize gem to sanitize output. Using the sanitizer within this formatter fixes [point 3 in this comment](https://github.com/radar/forem/issues/359#issuecomment-28790213).

Thanks!
